### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -3,7 +3,6 @@ name: Require Linked Issue
 on:
   pull_request_target:
     types: [opened, edited, reopened, synchronize]
-  workflow_call:
 
 permissions:
   issues: read
@@ -14,15 +13,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check-linked-issue:
-    runs-on: ubuntu-latest
-    name: Check linked issues
-    steps:
-      - uses: nearform-actions/github-action-check-linked-issues@v1
-        with:
-          exclude-branches: "dependabot/**,release/**,openapi-sync/**,plugin-sync/**,deps/**,sync/**,docs/update-*"
-          custom-message: >-
-            This PR must be linked to a GitHub issue. Use 'Closes #123'
-            in the PR description, or link an issue from the sidebar.
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  check:
+    uses: f5xc-salesdemos/docs-control/.github/workflows/reusable-require-linked-issue.yml@main
+    secrets: inherit


### PR DESCRIPTION
Closes #9

Synced managed files from `f5xc-salesdemos/docs-control` canonical source:

- .github/workflows/require-linked-issue.yml