### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -14,7 +14,9 @@
     "api-specs": [".ruff.toml", ".python-lint", ".mypy.ini"],
     "api-specs-enriched": [".ruff.toml", ".python-lint", ".mypy.ini"],
     "vscode-xcsh": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg", "README.md"],
-    "i18n-core": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"]
+    "i18n-core": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"],
+    "console": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"],
+    "xcsh-chrome-extension": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"]
   },
   "protected_files": [
     ".github/workflows/github-pages-deploy.yml",
@@ -22,6 +24,9 @@
     ".github/workflows/require-linked-issue.yml",
     ".github/workflows/super-linter.yml",
     ".github/workflows/dependabot-auto-merge.yml",
+    ".github/workflows/auto-merge.yml",
+    ".github/workflows/code-review.yml",
+    ".github/workflows/translation-audit.yml",
     ".github/PULL_REQUEST_TEMPLATE.md",
     ".github/ISSUE_TEMPLATE/bug_report.md",
     ".github/ISSUE_TEMPLATE/feature_request.md",
@@ -43,6 +48,7 @@
     ".editorconfig-checker.json",
     ".checkov.yaml",
     "zizmor.yaml",
+    "actionlint.yml",
     ".shellcheckrc",
     ".codespellrc",
     ".gitleaks.toml",

--- a/.claude/hooks/protect-managed-files.sh
+++ b/.claude/hooks/protect-managed-files.sh
@@ -4,10 +4,14 @@
 # Exit 0 = allow, Exit 2 = block (stderr shown to Claude).
 set -euo pipefail
 
-# ── Guard: exit if no stdin data (e.g., linter running script) ───────
-# read -t 0 checks if stdin has data without consuming it.
-# BASH_EXEC and other linters run scripts without piped input.
-if ! read -t 0 2>/dev/null; then
+# ── Guard: skip when there is no piped hook payload (e.g. a linter or shell
+# completion executing the script directly). A TTY on stdin means no hook input;
+# reading it would block. We test the descriptor type rather than `read -t 0`
+# because bash 3.2 (macOS /bin/bash) does NOT detect piped data with `read -t 0`
+# — it always reports "no data", which silently disabled this hook on macOS.
+# With a pipe/redirect on stdin we fall through and read it below; an empty
+# payload is handled by the `FILE_PATH` emptiness check further down.
+if [ -t 0 ]; then
   exit 0
 fi
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,7 +1,12 @@
 ---
 name: Dependabot Auto-Merge
 
-on: pull_request_target
+on:
+  # zizmor: ignore[dangerous-triggers] — Dependabot PRs get a read-only token under
+  # `pull_request`, so pull_request_target is required to approve and merge them.
+  # Gated to actor == dependabot[bot]; the caller only dispatches the reusable
+  # workflow — no PR-code checkout or exec.
+  pull_request_target:
 
 permissions:
   contents: write

--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -2,6 +2,10 @@
 name: Require Linked Issue
 
 on:
+  # zizmor: ignore[dangerous-triggers] — this caller needs pull-requests:write on
+  # fork PRs so the required linked-issue check can post its status/comment; a plain
+  # `pull_request` gives forks a read-only token and the required check deadlocks.
+  # The caller only dispatches the reusable workflow — no PR-code checkout or exec.
   pull_request_target:
     types: [opened, edited, reopened, synchronize]
 


### PR DESCRIPTION
Closes #579

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- .github/workflows/require-linked-issue.yml
- .github/workflows/dependabot-auto-merge.yml
- .claude/governance.json
- .claude/hooks/protect-managed-files.sh