### PR TITLE
docs: resolve Markdown lint violations

### DIFF
--- a/docs/en/bigip-configuration.mdx
+++ b/docs/en/bigip-configuration.mdx
@@ -283,6 +283,7 @@ self IP).
 1. Example BGP configuration:
 
 :::caution[Replace placeholder values]
+
 - `xCUSTOMER_ASNx` — your public ASN registered with ARIN (or
   equivalent RIR). A **public ASN is required** for routed DDoS
   because the Cloud will announce your prefixes globally.
@@ -292,6 +293,7 @@ self IP).
 - `xF5_XC_ASNx` — Cloud ASN (provided by the SOC).
 - `xBGP_PASSWORDx` — the agreed BGP MD5 password (or match Console
   "default secret"). Never reuse this password for other services.
+
 :::
 
 **BIG-IP-A** (router-id `xBIGIP_A_OUTER_V4x`, neighbors C1-T1 + C2-T1):

--- a/docs/en/protected-prefix.mdx
+++ b/docs/en/protected-prefix.mdx
@@ -11,7 +11,7 @@ The **protected prefix** is your organization's public IP address block that
 Cloud defends against DDoS attacks.
 
 | Requirement | IPv4 | IPv6 |
-|-------------|------|------|
+| ------------- | ------ | ------ |
 | **Minimum size** | /24 (256 IPs) | /48 |
 | **Routability** | Publicly routable (non-RFC 1918) | Global unicast (non-ULA) |
 | **Registration** | RIR-assigned (ARIN, RIPE, APNIC) | RIR-assigned |

--- a/docs/en/verification.mdx
+++ b/docs/en/verification.mdx
@@ -85,6 +85,7 @@ If BGP does not establish:
    reason.
 1. On each HA unit, verify the unit's own tunnels are up and its
    own BGP neighbors are configured (not the other unit's).
+
 :::
 
 ### XC Console
@@ -95,4 +96,3 @@ Navigate to **DDoS and Transit Services >
 - Traffic by network, zone, application.
 - Blocked vs. allowed traffic.
 - Attack details and scrubbing actions.
-


### PR DESCRIPTION
## Summary

- normalize Markdown tables and structural formatting for the newly enforced fleet rules
- tag schematic and command fences where the same touched files exposed untagged blocks
- keep translated content untouched for its planned final regeneration

Closes #666

## Testing

- markdownlint-cli 0.49.1 and governed prose gate on every changed Markdown/MDX file
- shellcheck and shfmt over every tracked shell script
- `git diff --check origin/main...HEAD`
