### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/actionlint.yml
+++ b/actionlint.yml
@@ -2,5 +2,6 @@
 self-hosted-runner:
   labels:
     - terraform-provider-xcsh
+    - ubuntu-24.04-arm
 
 config-variables: null


### PR DESCRIPTION
Closes #768

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- actionlint.yml