### PR TITLE
fix(docs): remove invalid MDX verification marker

### DIFF
--- a/docs/en/index.mdx
+++ b/docs/en/index.mdx
@@ -9,5 +9,3 @@ sidebar:
   hidden: true
   order: 0
 ---
-
-<!-- linked-issue verification: #839 -->


### PR DESCRIPTION
Removes the obsolete HTML verification marker that the MDX parser rejects, allowing the post-ARC-cutover Pages acceptance run to build the current documentation.

Validation:

- pinned docs-builder digest with `--pull=never`
- MDX prose lint
- staged and changed-scope PII enforcement scans

Closes #860